### PR TITLE
[US-938] Handle Division by Zero

### DIFF
--- a/dataset/sequence/continuous_range.go
+++ b/dataset/sequence/continuous_range.go
@@ -71,7 +71,10 @@ func (r ContinuousRange) String() string {
 // Translate maps a given value into the ContinuousRange space.
 func (r ContinuousRange) Translate(value float64) int {
 	normalized := value - r.Min
-	ratio := normalized / r.GetDelta()
+	ratio := 0.0
+	if r.Max != r.Min {
+		ratio = normalized / r.GetDelta()
+	}
 
 	if r.IsDescending() {
 		return r.Domain - int(math.Ceil(ratio*float64(r.Domain)))

--- a/dataset/sequence/continuous_range_test.go
+++ b/dataset/sequence/continuous_range_test.go
@@ -21,3 +21,14 @@ func TestRangeTranslate(t *testing.T) {
 	require.Equal(t, 1000, r.Translate(8.0))
 	require.Equal(t, 572, r.Translate(5.0))
 }
+
+func TestRangeTranslateEqaulMinMax(t *testing.T) {
+	r := ContinuousRange{
+		Domain: 370,
+		Min:    0,
+		Max:    0,
+	}
+
+	result := r.Translate(0)
+	require.Equal(t, 0, result)
+}


### PR DESCRIPTION
This PR provides a fix for an issue caused by division by zero.
Detailed description is given in this ticket

https://unidoc.atlassian.net/browse/US-938

This also fixes the render test differences between arm64 and amd64 machines in unipdf.

https://unidoc.atlassian.net/browse/US-407

The test I provided here is a direct recreation of the case which caused the original issue on `US-407`. 